### PR TITLE
Replace em dash with en dash (or vise versa)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Automation is key for streamlining your work processes, and [GitHub Actions](htt
    ![Use this template](https://user-images.githubusercontent.com/1221423/169618716-fb17528d-f332-4fc5-a11a-eaa23562665e.png)
 2. In the new tab, follow the prompts to create a new repository.
    - For owner, choose your personal account or an organization to host the repository.
-   - We recommend creating a public repository—private repositories will [use Actions minutes](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions).
+   - We recommend creating a public repository-private repositories will [use Actions minutes](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions).
    ![Create a new repository](https://user-images.githubusercontent.com/1221423/169618722-406dc508-add4-4074-83f0-c7a7ad87f6f3.png)
 3. After your new repository is created, wait about 20 seconds, then refresh the page. Follow the step-by-step instructions in the new repository's README.
 


### PR DESCRIPTION
The original `-` in the word `private-repositories` was creating a false positive in the detection action and causing the workflow to fail. Replacing that dash with the "standard" one caused that error to go away and allow the action to resolve successfully. The better solution might be to adjust the emoji checking script (perhaps something similar to the solution described in [this Slack Overflow post](https://stackoverflow.com/questions/52266347/grep-for-emojis-in-linux)).

### Why:

Workaround for https://github.com/skills/hello-github-actions/issues/7

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
