### PR TITLE
Fixed the broken link in the readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Automation is key for streamlining your work processes, and [GitHub Actions](htt
 - **Who is this for**: Developers, DevOps engineers, students, managers, teams, GitHub users.
 - **What you'll learn**: How to create workflow files, trigger workflows, and find workflow logs.
 - **What you'll build**: An Actions workflow that will check emoji shortcode references in Markdown files.
-- **Prerequisites**: In this course you will work with issues and pull requests, as well as edit files. We recommend you take the [Introduction to GitHub](/skills/introduction-to-github) course first.
+- **Prerequisites**: In this course you will work with issues and pull requests, as well as edit files. We recommend you take the [Introduction to GitHub](https://github.com/skills/introduction-to-github) course first.
 - **How long**: This course is five steps long and can be finished in less than two hours.
 
 ## How to start this course


### PR DESCRIPTION
Fixed the "Introduction to GitHub" link in the Readme file.

### Why:

Clicking on the link was going to the 404 page.

### What's being changed:

Link checked and re-edited. Currently it opens the correct page when clicked.

### Check off the following:

- [y] For workflow changes, I have verified the Actions workflows function as expected.
- [y] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
