### PR TITLE
Remove wrong text fragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Merge your pull request so the action will be a part of the `main` branch.
 
 _You've now got a fully functioning workflow! :smile:_
 
-Your new action will run any time a new commit is created or pushed to the remote repository. Since you just created a commit, the workflow should have been triggered.
+Your new action will run any time a pull request has been opened.
 
 **Seeing your _action_ in action**: The status of your action is shown in a pull request before you merge, look for **All checks have passed** when you try out the steps below. You can also view them from the **Actions** tab in your repository. From there, you will see all the actions that have run, and you can click on each action to view details and access log files.
 


### PR DESCRIPTION
### Why:

Closes #26 

### What's being changed:

I'm removing a text fragment that can cause confusion to learners.

Before:
```
Your new action will run any time a new commit is created or pushed to the remote repository. Since 
you just created a commit, the workflow should have been triggered.
```

After:

```
Your new action will run any time a new pull request has been opened.
```` 

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
