### PR TITLE
Ask learner to create PR manually and add `permissions`

### DIFF
--- a/.github/workflows/0-start.yml
+++ b/.github/workflows/0-start.yml
@@ -16,9 +16,7 @@ on:
 permissions:
   # Need `contents: read` to checkout the repository
   # Need `contents: write` to update the step metadata
-  # Need `pull-requests: write` to create a pull request
   contents: write
-  pull-requests: write
 
 jobs:
   # Get the current step from .github/script/STEP so we can
@@ -58,8 +56,8 @@ jobs:
         with:
           fetch-depth: 0 # Let's get all the branches
 
-      # Make a branch, file, commit, and pull request for the learner
-      - name: Prepare a pull request, branch, and file
+      # Make a branch, file, and commit for the learner
+      - name: Prepare a branch, and file
         run: |
           echo "Make sure we are on step 0"
           if [ "$(cat .github/script/STEP)" != 0 ]
@@ -79,11 +77,7 @@ jobs:
           
           echo "Push"
           git push --set-upstream origin $BRANCH
-
-          echo "Make a pull request"
-          # Reference https://cli.github.com/manual/gh_pr_create
-          gh pr create --title "Post welcome comment workflow" --body "Post welcome comment workflow"
-
+          
           echo "Restore main"
           git checkout main
         env:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ To get you started, we used actions to go ahead and made a branch and pull reque
 ### :keyboard: Activity: Create a workflow file
 
 1. Open a new browser tab, and navigate to this same repository. Then, work on the steps in your second tab while you read the instructions in this tab.
+1. Create a pull request to view all the changes you'll make throughout this course. Click the **Pull Requests** tab, click **New pull request**, set `base: main` and `compare:welcome-workflow`.
 1. Navigate to the **Code** tab.
 1. From the **main** branch dropdown, click on the **welcome-workflow** branch.
 1. Navigate to the `.github/workflows/` folder, then select **Add file** and click on **Create new file**.
@@ -185,7 +186,8 @@ Merge your changes so the action will be a part of the `main` branch.
 
 ### :keyboard: Activity: Merge your workflow file
 
-1. Click the **Pull Requests** tab, click **New pull request**, set `base: main` and `compare:welcome-workflow`.
+1. In your repo, click on the **Pull requests** tab.
+1. Click on the pull request you created in step 1.
 1. Click **Merge pull request**, then click **Confirm merge**.
 1. Optionally, click **Delete branch** to delete your `welcome-workflow` branch.
 1. Wait about 20 seconds for actions to run, then refresh this page (the one you're following instructions from) and an action will automatically close this step and open the next one.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Here's what it means:
 
 - `name: Post welcome comment` gives your workflow a name. This name appears on any pull request or in the Actions tab of your repository.
 - `on: pull_request: types: [opened]` indicates that your workflow will execute anytime a pull request opens in your repository.
-- `permissions` is used to assign the workflow permissions to operate on the repository
+- `permissions` assigns the workflow permissions to operate on the repository
 - `pull-requests: write` gives the workflow permission to write to pull requests. This is needed to create the welcome comment. 
 
 Next, we need to specify jobs to run.

--- a/README.md
+++ b/README.md
@@ -181,15 +181,14 @@ In our action, we post a comment on the pull request using a [bash](https://en.w
 
 _You're now able to write and run an Actions workflow! :sparkles:_
 
-Merge your pull request so the action will be a part of the `main` branch.
+Merge your changes so the action will be a part of the `main` branch.
 
 ### :keyboard: Activity: Merge your workflow file
 
-1. In your repo, click on the **Pull requests** tab.
-2. Click on the **Post welcome comment workflow** pull request.
-3. Click **Merge pull request**, then click **Confirm merge**.
-4. Optionally, click **Delete branch** to delete your `welcome-workflow` branch.
-5. Wait about 20 seconds for actions to run, then refresh this page (the one you're following instructions from) and an action will automatically close this step and open the next one.
+1. Click the **Pull Requests** tab, click **New pull request**, set `base: main` and `compare:welcome-workflow`.
+1. Click **Merge pull request**, then click **Confirm merge**.
+1. Optionally, click **Delete branch** to delete your `welcome-workflow` branch.
+1. Wait about 20 seconds for actions to run, then refresh this page (the one you're following instructions from) and an action will automatically close this step and open the next one.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ To get you started, we used actions to go ahead and made a branch and pull reque
    on:
      pull_request:
        types: [opened]
+   permissions:
+     pull-requests: write
    ```
 1. To commit your changes, click **Commit new file**.
 1. Wait about 20 seconds for actions to run, then refresh this page (the one you're following instructions from) and an action will automatically close this step and open the next one.
@@ -102,6 +104,8 @@ Here's what it means:
 
 - `name: Post welcome comment` gives your workflow a name. This name appears on any pull request or in the Actions tab of your repository.
 - `on: pull_request: types: [opened]` indicates that your workflow will execute anytime a pull request opens in your repository.
+- `permissions` is used to assign the workflow permissions to operate on the repository
+- `pull-requests: write` gives the workflow permission to write to pull requests. This is needed to create the welcome comment. 
 
 Next, we need to specify jobs to run.
 
@@ -118,6 +122,8 @@ In this step of our exercise, we will add a "build" job. We will specify `ubuntu
    on:
      pull_request:
        types: [opened]
+   permissions:
+     pull-requests: write
    jobs:
      build:
        name: Post welcome comment
@@ -155,6 +161,8 @@ In our action, we post a comment on the pull request using a [bash](https://en.w
    on:
      pull_request:
        types: [opened]
+   permissions:
+     pull-requests: write
    jobs:
      build:
        name: Post welcome comment


### PR DESCRIPTION
### Why:

Relates to https://github.com/github/skills/issues/96

The GITHUB_TOKEN we use in the Actions workflows [no longer allows](https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/) the creation of PRs.

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

- Updating the course to remove any automatically-generated PRs. The learner is now asked to create any necessary PRs.
- Adds the `permission` field to the workflow code snippet in the course so the workflow has permission to comment on the PR. **I think this would be better as a separate step to the course, but I tried to change as little as possible for this PR.**

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
