### PR TITLE
doc: github-token need to have write permission

### DIFF
--- a/.github/steps/5-trigger.md
+++ b/.github/steps/5-trigger.md
@@ -18,6 +18,7 @@ Your new action will run any time a pull request has been opened.
 
 1. Make a new branch named `test-workflow`.
 1. Commit any change to your branch, such as adding an emoji to your README.md file.
+1. Validate that your GITHUB_TOKEN has write permission on your repository. (Go to Settings->Actions->General->Workflow permissions)
 1. Create the pull request on your branch.
 1. See your action run on your pull request.
 1. Wait about 20 seconds for actions to run, then refresh this page (the one you're following instructions from) and an action will automatically close this step and open the next one.

--- a/.github/steps/5-trigger.md
+++ b/.github/steps/5-trigger.md
@@ -16,9 +16,9 @@ Your new action will run any time a pull request has been opened.
 
 ### :keyboard: Activity: Trigger the workflow
 
+1. Click the **Settings** tab for your repository. In the left panel, click **Actions** then **General**. Under "Workflow permissions," make sure that **Read and write permissions** is selected. This allows your workflows to write to this repository.
 1. Make a new branch named `test-workflow`.
 1. Commit any change to your branch, such as adding an emoji to your README.md file.
-1. Validate that your GITHUB_TOKEN has write permission on your repository. (Go to Settings->Actions->General->Workflow permissions)
 1. Create the pull request on your branch.
 1. See your action run on your pull request.
 1. Wait about 20 seconds for actions to run, then refresh this page (the one you're following instructions from) and an action will automatically close this step and open the next one.


### PR DESCRIPTION
### Summary
If you fork this project and follow the instructions, there is no mention about GITHUB_TOKEN permission (default only allow read access)


### Changes
Adding documentation about how to grant write permission to GITHUB_TOKEN.

Closes:
https://github.com/skills/hello-github-actions/issues/70