### PR TITLE
fix: Revert "Bump skills/action-text-variables from 2 to 3"

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build comment - add step content
         id: build-comment
-        uses: skills/action-text-variables@v3
+        uses: skills/action-text-variables@v2
         with:
           template-file: ${{ env.STEP_1_FILE }}
           template-vars: |

--- a/.github/workflows/1-step.yml
+++ b/.github/workflows/1-step.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Build message - step results
         id: build-message-step-results
-        uses: skills/action-text-variables@v3
+        uses: skills/action-text-variables@v2
         with:
           template-file: exercise-toolkit/markdown-templates/step-feedback/step-results-table.md
           template-vars: |
@@ -120,7 +120,7 @@ jobs:
 
       - name: Build message - step finished
         id: build-message-step-finish
-        uses: skills/action-text-variables@v3
+        uses: skills/action-text-variables@v2
         with:
           template-file: exercise-toolkit/markdown-templates/step-feedback/step-finished-prepare-next-step.md
           template-vars: |

--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Build message - step results
         id: build-message-step-results
-        uses: skills/action-text-variables@v3
+        uses: skills/action-text-variables@v2
         with:
           template-file: exercise-toolkit/markdown-templates/step-feedback/step-results-table.md
           template-vars: |
@@ -99,7 +99,7 @@ jobs:
 
       - name: Build message - step finished
         id: build-message-step-finish
-        uses: skills/action-text-variables@v3
+        uses: skills/action-text-variables@v2
         with:
           template-file: exercise-toolkit/markdown-templates/step-feedback/step-finished-prepare-next-step.md
           template-vars: |

--- a/.github/workflows/3-step.yml
+++ b/.github/workflows/3-step.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Build message - step results
         id: build-message-step-results
-        uses: skills/action-text-variables@v3
+        uses: skills/action-text-variables@v2
         with:
           template-file: exercise-toolkit/markdown-templates/step-feedback/step-results-table.md
           template-vars: |
@@ -121,7 +121,7 @@ jobs:
 
       - name: Build message - step finished
         id: build-message-step-finish
-        uses: skills/action-text-variables@v3
+        uses: skills/action-text-variables@v2
         with:
           template-file: exercise-toolkit/markdown-templates/step-feedback/step-finished-prepare-next-step.md
           template-vars: |


### PR DESCRIPTION
Reverts skills/hello-github-actions#324

This is not a simple version bump. v3 is a major update and introduces breaking changes that require using updated templates and verifying the format in the learning step files.

A user has already reported in #334 that the exercise is broken.