### PR TITLE
fix: update raven-actions/actionlint version and lock actionlint version

### DIFF
--- a/.github/workflows/3-step.yml
+++ b/.github/workflows/3-step.yml
@@ -49,9 +49,11 @@ jobs:
       - name: Lint welcome.yml with actionlint
         id: actionlint-check
         continue-on-error: true
-        uses: raven-actions/actionlint@3a24062651993d40fed1019b58ac6fbdfbf276cc # v2.0.1
+        uses: raven-actions/actionlint@v2.1.1
         with:
           files: .github/workflows/welcome.yml
+          version: 1.7.10
+          fail-on-error: true
 
       - name: Check for steps section in welcome.yml
         id: check-steps-section
@@ -60,7 +62,6 @@ jobs:
         with:
           text-file: .github/workflows/welcome.yml
           keyphrase: "steps:"
-          fail-on-error: true
 
       - name: Check for gh pr comment command in welcome.yml
         id: check-gh-pr-comment


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

This pull request updates the workflow configuration in `.github/workflows/3-step.yml` to improve the linting process for `welcome.yml` and adjusts error handling for a specific check. The most important changes are:

**Workflow Linting Improvements:**

* Upgraded the `raven-actions/actionlint` action from version `v2.0.1` to `v2.1.1`, ensuring the latest features and bug fixes are used.
* Added explicit `version: 1.7.10` and `fail-on-error: true` parameters to the `actionlint` step for more controlled and strict linting behavior.

**Error Handling Adjustments:**

* Removed the `fail-on-error: true` option from the "Check for steps section in welcome.yml" step, which changes how failures in this step are handled.

### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Fixes: https://github.com/skills/hello-github-actions/issues/350
Fixes: https://github.com/skills/hello-github-actions/issues/349

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
